### PR TITLE
Fix compatibility with PHP 5.6

### DIFF
--- a/src/ConsoleCommandsProvider.php
+++ b/src/ConsoleCommandsProvider.php
@@ -5,7 +5,6 @@ namespace glen\PimpleConsoleApplication;
 use ED\Resizer\Command;
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
-use Symfony\Component\Console\Application;
 
 class ConsoleCommandsProvider implements ServiceProviderInterface
 {

--- a/src/ServiceProvider/ConsoleCommandsProvider.php
+++ b/src/ServiceProvider/ConsoleCommandsProvider.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace glen\PimpleConsoleApplication;
+namespace glen\PimpleConsoleApplication\ServiceProvider;
 
-use ED\Resizer\Command;
+use glen\PimpleConsoleApplication\Application;
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
 
@@ -28,7 +28,6 @@ class ConsoleCommandsProvider implements ServiceProviderInterface
      */
     protected function getCommands()
     {
-        return array(
-        );
+        return array();
     }
 }


### PR DESCRIPTION
```
PHP Fatal error:  Cannot use Symfony\Component\Console\Application as Application because the name is already in use in /usr/share/dvideo/vendor/glen/pimple-console-application/src/ConsoleCommandsProvider.php on line 8
```