### PR TITLE
Rename Application to PimpleConsoleApplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ composer require glen/pimple-console-application
 # bin/console.php
 <?php
 
-use glen\PimpleConsoleApplication\Application;
+use glen\PimpleConsoleApplication\PimpleConsoleApplication;
 
-$app = new Application();
+$app = new PimpleConsoleApplication();
 $app->run();
 ```

--- a/src/Command/BaseCommand.php
+++ b/src/Command/BaseCommand.php
@@ -2,7 +2,7 @@
 
 namespace glen\PimpleConsoleApplication\Command;
 
-use glen\PimpleConsoleApplication\Application;
+use glen\PimpleConsoleApplication\PimpleConsoleApplication;
 use Pimple\Container;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -59,7 +59,7 @@ abstract class BaseCommand extends Command
      */
     public function getContainer()
     {
-        /** @var Application $application */
+        /** @var PimpleConsoleApplication $application */
         $application = $this->getApplication();
 
         return $application->getContainer();

--- a/src/PimpleConsoleApplication.php
+++ b/src/PimpleConsoleApplication.php
@@ -3,9 +3,9 @@
 namespace glen\PimpleConsoleApplication;
 
 use Pimple\Container;
-use Symfony\Component\Console\Application as BaseApplication;
+use Symfony\Component\Console\Application;
 
-class Application extends BaseApplication
+class PimpleConsoleApplication extends Application
 {
     /** @var Container */
     protected $container;

--- a/src/ServiceProvider/ConsoleCommandsProvider.php
+++ b/src/ServiceProvider/ConsoleCommandsProvider.php
@@ -2,16 +2,16 @@
 
 namespace glen\PimpleConsoleApplication\ServiceProvider;
 
-use glen\PimpleConsoleApplication\Application;
+use glen\PimpleConsoleApplication\PimpleConsoleApplication;
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
 
 class ConsoleCommandsProvider implements ServiceProviderInterface
 {
-    /** @var Application */
+    /** @var PimpleConsoleApplication */
     private $console;
 
-    public function __construct(Application $console)
+    public function __construct(PimpleConsoleApplication $console)
     {
         $this->console = $console;
     }


### PR DESCRIPTION
This is to avoid the need for alias import.