### PR TITLE
Rename MonologTrait to LoggerTrait

### DIFF
--- a/src/Command/BaseCommand.php
+++ b/src/Command/BaseCommand.php
@@ -3,7 +3,7 @@
 namespace glen\PimpleConsoleApplication\Command;
 
 use glen\PimpleConsoleApplication\PimpleConsoleApplication;
-use glen\PimpleConsoleApplication\Traits\MonologTrait;
+use glen\PimpleConsoleApplication\Traits\LoggerTrait;
 use Pimple\Container;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 abstract class BaseCommand extends Command
 {
-    use MonologTrait;
+    use LoggerTrait;
 
     const DEBUG = OutputInterface::VERBOSITY_DEBUG;
     const VERBOSE = OutputInterface::VERBOSITY_VERBOSE;

--- a/src/Traits/LoggerTrait.php
+++ b/src/Traits/LoggerTrait.php
@@ -3,11 +3,11 @@
 namespace glen\PimpleConsoleApplication\Traits;
 
 use Psr\Log\LoggerInterface;
-use Psr\Log\LoggerTrait;
+use Psr\Log\LoggerTrait as PsrLoggerTrait;
 
-trait MonologTrait
+trait LoggerTrait
 {
-    use LoggerTrait;
+    use PsrLoggerTrait;
 
     /** @var LoggerInterface */
     protected $logger;


### PR DESCRIPTION
The trait is not Monolog specific.

NOTE: This is breaking change. and it's fine as every 0.x release is major version with semver specification.